### PR TITLE
fix fatal error RC1015: cannot open include file 'afxres.h'. in pcsxr.rc

### DIFF
--- a/pcsxr.rc
+++ b/pcsxr.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
replace afxres.h with windows.h in pcsxr.rc as recommended in this thread http://stackoverflow.com/questions/3566018/cannot-open-include-file-afxres-h-in-vc2010-express